### PR TITLE
feat: bootstrap repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # FeatureFlagSetLD
-FeatureFlagSetLD
+
+## ⚠️  WARNINGS ⚠️
+
+- **THIS IS A PUBLIC REPO**
+- **THIS IS NOT A RAZEE FORK**
+
+This is effectively a tooling repo, enabling us to customize Razee's deployment
+files to better suite our needs.

--- a/deployment/kubernetes/wave0.yaml.envsubst
+++ b/deployment/kubernetes/wave0.yaml.envsubst
@@ -1,0 +1,322 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: featureflagsetld-controller-list
+  annotations:
+    razee.io/git-repo: "${GIT_URL}"
+    razee.io/commit-sha: "${GIT_SHA1}"
+    razee.io/build-tag: "${BUILD_TAG}"
+    razee.io/branch: "${GIT_BRANCH}"
+type: array
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: featureflagsetld-controller
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        razee/watch-resource: "lite"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: featureflagsetld-controller
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: featureflagsetld-controller
+            razee/watch-resource: "lite"
+          name: featureflagsetld-controller
+        spec:
+          serviceAccountName: razeedeploy-sa
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - image: "quay.io/razee/featureflagsetld:${WAVE0_VERSION}"
+              resources:
+                limits:
+                  memory: 200Mi
+                  cpu: 1.0
+                requests:
+                  memory: 75Mi
+                  cpu: 40m
+              env:
+                - name: USER_AGENT_NAME
+                  value: razee-io/featureflagsetld
+                - name: USER_AGENT_VERSION
+                  value: "${WAVE0_VERSION}"
+                - name: CRD_WATCH_TIMEOUT_SECONDS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: razeedeploy-overrides
+                      key: CRD_WATCH_TIMEOUT_SECONDS
+                      optional: true
+              imagePullPolicy: Always
+              name: featureflagsetld-controller
+              livenessProbe:
+                exec:
+                  command:
+                    - sh/liveness.sh
+                initialDelaySeconds: 30
+                periodSeconds: 150
+                timeoutSeconds: 30
+                failureThreshold: 1
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      # name must match the spec fields below, and be in the form: <plural>.<group>
+      name: featureflagsetsld.deploy.razee.io
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        deploy.razee.io/Reconcile: "false"
+    spec:
+      # group name to use for REST API: /apis/<group>/<version>
+      group: deploy.razee.io
+      # either Namespaced or Cluster
+      scope: Namespaced
+      names:
+        # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+        plural: featureflagsetsld
+        # singular name to be used as an alias on the CLI and for display
+        singular: featureflagsetld
+        # kind is normally the CamelCased singular type. Your resource manifests use this.
+        kind: FeatureFlagSetLD
+        # shortNames allow shorter string to match your resource on the CLI
+        shortNames:
+          - ffsld
+      # list of versions supported by this CustomResourceDefinition
+      versions:
+        - name: v1alpha1
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: false
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+        - name: v1alpha2
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: true
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  allOf:
+                    - # you must define oneOf:
+                      oneOf:
+                        - required: [sdkKey]
+                        - required: [sdkKeyRef]
+                    - # you must define oneOf:
+                      oneOf:
+                        - # neither 'identityRef' nor 'identityKey' is used
+                          not:
+                            anyOf:
+                              - required: [identityRef]
+                              - required: [identityKey]
+                        - # 'identityRef' is used by itself
+                          required: [identityRef]
+                          not:
+                            required: [identityKey]
+                        - # 'identityRef' and 'identityKey' are used together
+                          required: [identityRef, identityKey]
+                  properties:
+                    sdkKey:
+                      type: string
+                    sdkKeyRef:
+                      type: object
+                      required: [valueFrom]
+                      properties:
+                        valueFrom:
+                          type: object
+                          required: [secretKeyRef]
+                          properties:
+                            secretKeyRef:
+                              type: object
+                              required: [name, key]
+                              properties:
+                                name:
+                                  type: string
+                                key:
+                                  type: string
+                                namespace:
+                                  type: string
+                    identityKey:
+                      type: string
+                    identityRef:
+                      type: object
+                      anyOf:
+                        - required: [envFrom]
+                        - required: [env]
+                      properties:
+                        envFrom:
+                          type: array
+                          items:
+                            type: object
+                            oneOf:
+                              - required: [configMapRef]
+                              - required: [secretMapRef]
+                              - required: [genericMapRef]
+                            properties:
+                              optional:
+                                type: boolean
+                              configMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              secretMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              genericMapRef:
+                                type: object
+                                required: [apiVersion, kind, name]
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            allOf:
+                              - required: [name]
+                              - # all array items should be oneOf ['value', 'valueFrom']
+                                oneOf:
+                                  - required: [value]
+                                    # if 'value', neither 'optional' nor 'default' may be used
+                                    not:
+                                      anyOf:
+                                        - required: [default]
+                                        - required: [optional]
+                                  - required: [valueFrom]
+                                    # if 'valueFrom', you must define oneOf:
+                                    oneOf:
+                                      - # neither 'optional' nor 'default' is used
+                                        not:
+                                          anyOf:
+                                            - required: [default]
+                                            - required: [optional]
+                                      - # 'optional' is used by itself
+                                        required: [optional]
+                                        not:
+                                          required: [default]
+                                      - # 'optional' and 'default' are used together IFF optional == true
+                                        required: [optional, default]
+                                        properties:
+                                          optional:
+                                            enum: [true]
+                            properties:
+                              optional:
+                                type: boolean
+                              default:
+                                x-kubernetes-int-or-string: true
+                              name:
+                                type: string
+                              value:
+                                x-kubernetes-int-or-string: true
+                              valueFrom:
+                                type: object
+                                oneOf:
+                                  - required: [configMapKeyRef]
+                                  - required: [secretKeyRef]
+                                  - required: [genericKeyRef]
+                                properties:
+                                  configMapKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  secretKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  genericKeyRef:
+                                    type: object
+                                    required: [apiVersion, kind, name, key]
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true

--- a/deployment/kubernetes/wave1.yaml.envsubst
+++ b/deployment/kubernetes/wave1.yaml.envsubst
@@ -1,0 +1,322 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: featureflagsetld-controller-list
+  annotations:
+    razee.io/git-repo: "${GIT_URL}"
+    razee.io/commit-sha: "${GIT_SHA1}"
+    razee.io/build-tag: "${BUILD_TAG}"
+    razee.io/branch: "${GIT_BRANCH}"
+type: array
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: featureflagsetld-controller
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        razee/watch-resource: "lite"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: featureflagsetld-controller
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: featureflagsetld-controller
+            razee/watch-resource: "lite"
+          name: featureflagsetld-controller
+        spec:
+          serviceAccountName: razeedeploy-sa
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - image: "quay.io/razee/featureflagsetld:${WAVE1_VERSION}"
+              resources:
+                limits:
+                  memory: 200Mi
+                  cpu: 1.0
+                requests:
+                  memory: 75Mi
+                  cpu: 40m
+              env:
+                - name: USER_AGENT_NAME
+                  value: razee-io/featureflagsetld
+                - name: USER_AGENT_VERSION
+                  value: "${WAVE1_VERSION}"
+                - name: CRD_WATCH_TIMEOUT_SECONDS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: razeedeploy-overrides
+                      key: CRD_WATCH_TIMEOUT_SECONDS
+                      optional: true
+              imagePullPolicy: Always
+              name: featureflagsetld-controller
+              livenessProbe:
+                exec:
+                  command:
+                    - sh/liveness.sh
+                initialDelaySeconds: 30
+                periodSeconds: 150
+                timeoutSeconds: 30
+                failureThreshold: 1
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      # name must match the spec fields below, and be in the form: <plural>.<group>
+      name: featureflagsetsld.deploy.razee.io
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        deploy.razee.io/Reconcile: "false"
+    spec:
+      # group name to use for REST API: /apis/<group>/<version>
+      group: deploy.razee.io
+      # either Namespaced or Cluster
+      scope: Namespaced
+      names:
+        # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+        plural: featureflagsetsld
+        # singular name to be used as an alias on the CLI and for display
+        singular: featureflagsetld
+        # kind is normally the CamelCased singular type. Your resource manifests use this.
+        kind: FeatureFlagSetLD
+        # shortNames allow shorter string to match your resource on the CLI
+        shortNames:
+          - ffsld
+      # list of versions supported by this CustomResourceDefinition
+      versions:
+        - name: v1alpha1
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: false
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+        - name: v1alpha2
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: true
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  allOf:
+                    - # you must define oneOf:
+                      oneOf:
+                        - required: [sdkKey]
+                        - required: [sdkKeyRef]
+                    - # you must define oneOf:
+                      oneOf:
+                        - # neither 'identityRef' nor 'identityKey' is used
+                          not:
+                            anyOf:
+                              - required: [identityRef]
+                              - required: [identityKey]
+                        - # 'identityRef' is used by itself
+                          required: [identityRef]
+                          not:
+                            required: [identityKey]
+                        - # 'identityRef' and 'identityKey' are used together
+                          required: [identityRef, identityKey]
+                  properties:
+                    sdkKey:
+                      type: string
+                    sdkKeyRef:
+                      type: object
+                      required: [valueFrom]
+                      properties:
+                        valueFrom:
+                          type: object
+                          required: [secretKeyRef]
+                          properties:
+                            secretKeyRef:
+                              type: object
+                              required: [name, key]
+                              properties:
+                                name:
+                                  type: string
+                                key:
+                                  type: string
+                                namespace:
+                                  type: string
+                    identityKey:
+                      type: string
+                    identityRef:
+                      type: object
+                      anyOf:
+                        - required: [envFrom]
+                        - required: [env]
+                      properties:
+                        envFrom:
+                          type: array
+                          items:
+                            type: object
+                            oneOf:
+                              - required: [configMapRef]
+                              - required: [secretMapRef]
+                              - required: [genericMapRef]
+                            properties:
+                              optional:
+                                type: boolean
+                              configMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              secretMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              genericMapRef:
+                                type: object
+                                required: [apiVersion, kind, name]
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            allOf:
+                              - required: [name]
+                              - # all array items should be oneOf ['value', 'valueFrom']
+                                oneOf:
+                                  - required: [value]
+                                    # if 'value', neither 'optional' nor 'default' may be used
+                                    not:
+                                      anyOf:
+                                        - required: [default]
+                                        - required: [optional]
+                                  - required: [valueFrom]
+                                    # if 'valueFrom', you must define oneOf:
+                                    oneOf:
+                                      - # neither 'optional' nor 'default' is used
+                                        not:
+                                          anyOf:
+                                            - required: [default]
+                                            - required: [optional]
+                                      - # 'optional' is used by itself
+                                        required: [optional]
+                                        not:
+                                          required: [default]
+                                      - # 'optional' and 'default' are used together IFF optional == true
+                                        required: [optional, default]
+                                        properties:
+                                          optional:
+                                            enum: [true]
+                            properties:
+                              optional:
+                                type: boolean
+                              default:
+                                x-kubernetes-int-or-string: true
+                              name:
+                                type: string
+                              value:
+                                x-kubernetes-int-or-string: true
+                              valueFrom:
+                                type: object
+                                oneOf:
+                                  - required: [configMapKeyRef]
+                                  - required: [secretKeyRef]
+                                  - required: [genericKeyRef]
+                                properties:
+                                  configMapKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  secretKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  genericKeyRef:
+                                    type: object
+                                    required: [apiVersion, kind, name, key]
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true

--- a/deployment/kubernetes/wave2.yaml.envsubst
+++ b/deployment/kubernetes/wave2.yaml.envsubst
@@ -1,0 +1,322 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: featureflagsetld-controller-list
+  annotations:
+    razee.io/git-repo: "${GIT_URL}"
+    razee.io/commit-sha: "${GIT_SHA1}"
+    razee.io/build-tag: "${BUILD_TAG}"
+    razee.io/branch: "${GIT_BRANCH}"
+type: array
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: featureflagsetld-controller
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        razee/watch-resource: "lite"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: featureflagsetld-controller
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: featureflagsetld-controller
+            razee/watch-resource: "lite"
+          name: featureflagsetld-controller
+        spec:
+          serviceAccountName: razeedeploy-sa
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - image: "quay.io/razee/featureflagsetld:${WAVE2_VERSION}"
+              resources:
+                limits:
+                  memory: 200Mi
+                  cpu: 1.0
+                requests:
+                  memory: 75Mi
+                  cpu: 40m
+              env:
+                - name: USER_AGENT_NAME
+                  value: razee-io/featureflagsetld
+                - name: USER_AGENT_VERSION
+                  value: "${WAVE2_VERSION}"
+                - name: CRD_WATCH_TIMEOUT_SECONDS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: razeedeploy-overrides
+                      key: CRD_WATCH_TIMEOUT_SECONDS
+                      optional: true
+              imagePullPolicy: Always
+              name: featureflagsetld-controller
+              livenessProbe:
+                exec:
+                  command:
+                    - sh/liveness.sh
+                initialDelaySeconds: 30
+                periodSeconds: 150
+                timeoutSeconds: 30
+                failureThreshold: 1
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      # name must match the spec fields below, and be in the form: <plural>.<group>
+      name: featureflagsetsld.deploy.razee.io
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        deploy.razee.io/Reconcile: "false"
+    spec:
+      # group name to use for REST API: /apis/<group>/<version>
+      group: deploy.razee.io
+      # either Namespaced or Cluster
+      scope: Namespaced
+      names:
+        # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+        plural: featureflagsetsld
+        # singular name to be used as an alias on the CLI and for display
+        singular: featureflagsetld
+        # kind is normally the CamelCased singular type. Your resource manifests use this.
+        kind: FeatureFlagSetLD
+        # shortNames allow shorter string to match your resource on the CLI
+        shortNames:
+          - ffsld
+      # list of versions supported by this CustomResourceDefinition
+      versions:
+        - name: v1alpha1
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: false
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+        - name: v1alpha2
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: true
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  allOf:
+                    - # you must define oneOf:
+                      oneOf:
+                        - required: [sdkKey]
+                        - required: [sdkKeyRef]
+                    - # you must define oneOf:
+                      oneOf:
+                        - # neither 'identityRef' nor 'identityKey' is used
+                          not:
+                            anyOf:
+                              - required: [identityRef]
+                              - required: [identityKey]
+                        - # 'identityRef' is used by itself
+                          required: [identityRef]
+                          not:
+                            required: [identityKey]
+                        - # 'identityRef' and 'identityKey' are used together
+                          required: [identityRef, identityKey]
+                  properties:
+                    sdkKey:
+                      type: string
+                    sdkKeyRef:
+                      type: object
+                      required: [valueFrom]
+                      properties:
+                        valueFrom:
+                          type: object
+                          required: [secretKeyRef]
+                          properties:
+                            secretKeyRef:
+                              type: object
+                              required: [name, key]
+                              properties:
+                                name:
+                                  type: string
+                                key:
+                                  type: string
+                                namespace:
+                                  type: string
+                    identityKey:
+                      type: string
+                    identityRef:
+                      type: object
+                      anyOf:
+                        - required: [envFrom]
+                        - required: [env]
+                      properties:
+                        envFrom:
+                          type: array
+                          items:
+                            type: object
+                            oneOf:
+                              - required: [configMapRef]
+                              - required: [secretMapRef]
+                              - required: [genericMapRef]
+                            properties:
+                              optional:
+                                type: boolean
+                              configMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              secretMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              genericMapRef:
+                                type: object
+                                required: [apiVersion, kind, name]
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            allOf:
+                              - required: [name]
+                              - # all array items should be oneOf ['value', 'valueFrom']
+                                oneOf:
+                                  - required: [value]
+                                    # if 'value', neither 'optional' nor 'default' may be used
+                                    not:
+                                      anyOf:
+                                        - required: [default]
+                                        - required: [optional]
+                                  - required: [valueFrom]
+                                    # if 'valueFrom', you must define oneOf:
+                                    oneOf:
+                                      - # neither 'optional' nor 'default' is used
+                                        not:
+                                          anyOf:
+                                            - required: [default]
+                                            - required: [optional]
+                                      - # 'optional' is used by itself
+                                        required: [optional]
+                                        not:
+                                          required: [default]
+                                      - # 'optional' and 'default' are used together IFF optional == true
+                                        required: [optional, default]
+                                        properties:
+                                          optional:
+                                            enum: [true]
+                            properties:
+                              optional:
+                                type: boolean
+                              default:
+                                x-kubernetes-int-or-string: true
+                              name:
+                                type: string
+                              value:
+                                x-kubernetes-int-or-string: true
+                              valueFrom:
+                                type: object
+                                oneOf:
+                                  - required: [configMapKeyRef]
+                                  - required: [secretKeyRef]
+                                  - required: [genericKeyRef]
+                                properties:
+                                  configMapKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  secretKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  genericKeyRef:
+                                    type: object
+                                    required: [apiVersion, kind, name, key]
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true

--- a/deployment/kubernetes/wave3.yaml.envsubst
+++ b/deployment/kubernetes/wave3.yaml.envsubst
@@ -1,0 +1,322 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: featureflagsetld-controller-list
+  annotations:
+    razee.io/git-repo: "${GIT_URL}"
+    razee.io/commit-sha: "${GIT_SHA1}"
+    razee.io/build-tag: "${BUILD_TAG}"
+    razee.io/branch: "${GIT_BRANCH}"
+type: array
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: featureflagsetld-controller
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        razee/watch-resource: "lite"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: featureflagsetld-controller
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: featureflagsetld-controller
+            razee/watch-resource: "lite"
+          name: featureflagsetld-controller
+        spec:
+          serviceAccountName: razeedeploy-sa
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - image: "quay.io/razee/featureflagsetld:${WAVE3_VERSION}"
+              resources:
+                limits:
+                  memory: 200Mi
+                  cpu: 1.0
+                requests:
+                  memory: 75Mi
+                  cpu: 40m
+              env:
+                - name: USER_AGENT_NAME
+                  value: razee-io/featureflagsetld
+                - name: USER_AGENT_VERSION
+                  value: "${WAVE3_VERSION}"
+                - name: CRD_WATCH_TIMEOUT_SECONDS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: razeedeploy-overrides
+                      key: CRD_WATCH_TIMEOUT_SECONDS
+                      optional: true
+              imagePullPolicy: Always
+              name: featureflagsetld-controller
+              livenessProbe:
+                exec:
+                  command:
+                    - sh/liveness.sh
+                initialDelaySeconds: 30
+                periodSeconds: 150
+                timeoutSeconds: 30
+                failureThreshold: 1
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      # name must match the spec fields below, and be in the form: <plural>.<group>
+      name: featureflagsetsld.deploy.razee.io
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        deploy.razee.io/Reconcile: "false"
+    spec:
+      # group name to use for REST API: /apis/<group>/<version>
+      group: deploy.razee.io
+      # either Namespaced or Cluster
+      scope: Namespaced
+      names:
+        # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+        plural: featureflagsetsld
+        # singular name to be used as an alias on the CLI and for display
+        singular: featureflagsetld
+        # kind is normally the CamelCased singular type. Your resource manifests use this.
+        kind: FeatureFlagSetLD
+        # shortNames allow shorter string to match your resource on the CLI
+        shortNames:
+          - ffsld
+      # list of versions supported by this CustomResourceDefinition
+      versions:
+        - name: v1alpha1
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: false
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+        - name: v1alpha2
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: true
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  allOf:
+                    - # you must define oneOf:
+                      oneOf:
+                        - required: [sdkKey]
+                        - required: [sdkKeyRef]
+                    - # you must define oneOf:
+                      oneOf:
+                        - # neither 'identityRef' nor 'identityKey' is used
+                          not:
+                            anyOf:
+                              - required: [identityRef]
+                              - required: [identityKey]
+                        - # 'identityRef' is used by itself
+                          required: [identityRef]
+                          not:
+                            required: [identityKey]
+                        - # 'identityRef' and 'identityKey' are used together
+                          required: [identityRef, identityKey]
+                  properties:
+                    sdkKey:
+                      type: string
+                    sdkKeyRef:
+                      type: object
+                      required: [valueFrom]
+                      properties:
+                        valueFrom:
+                          type: object
+                          required: [secretKeyRef]
+                          properties:
+                            secretKeyRef:
+                              type: object
+                              required: [name, key]
+                              properties:
+                                name:
+                                  type: string
+                                key:
+                                  type: string
+                                namespace:
+                                  type: string
+                    identityKey:
+                      type: string
+                    identityRef:
+                      type: object
+                      anyOf:
+                        - required: [envFrom]
+                        - required: [env]
+                      properties:
+                        envFrom:
+                          type: array
+                          items:
+                            type: object
+                            oneOf:
+                              - required: [configMapRef]
+                              - required: [secretMapRef]
+                              - required: [genericMapRef]
+                            properties:
+                              optional:
+                                type: boolean
+                              configMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              secretMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              genericMapRef:
+                                type: object
+                                required: [apiVersion, kind, name]
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            allOf:
+                              - required: [name]
+                              - # all array items should be oneOf ['value', 'valueFrom']
+                                oneOf:
+                                  - required: [value]
+                                    # if 'value', neither 'optional' nor 'default' may be used
+                                    not:
+                                      anyOf:
+                                        - required: [default]
+                                        - required: [optional]
+                                  - required: [valueFrom]
+                                    # if 'valueFrom', you must define oneOf:
+                                    oneOf:
+                                      - # neither 'optional' nor 'default' is used
+                                        not:
+                                          anyOf:
+                                            - required: [default]
+                                            - required: [optional]
+                                      - # 'optional' is used by itself
+                                        required: [optional]
+                                        not:
+                                          required: [default]
+                                      - # 'optional' and 'default' are used together IFF optional == true
+                                        required: [optional, default]
+                                        properties:
+                                          optional:
+                                            enum: [true]
+                            properties:
+                              optional:
+                                type: boolean
+                              default:
+                                x-kubernetes-int-or-string: true
+                              name:
+                                type: string
+                              value:
+                                x-kubernetes-int-or-string: true
+                              valueFrom:
+                                type: object
+                                oneOf:
+                                  - required: [configMapKeyRef]
+                                  - required: [secretKeyRef]
+                                  - required: [genericKeyRef]
+                                properties:
+                                  configMapKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  secretKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  genericKeyRef:
+                                    type: object
+                                    required: [apiVersion, kind, name, key]
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true

--- a/deployment/kubernetes/wave4.yaml.envsubst
+++ b/deployment/kubernetes/wave4.yaml.envsubst
@@ -1,0 +1,322 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: featureflagsetld-controller-list
+  annotations:
+    razee.io/git-repo: "${GIT_URL}"
+    razee.io/commit-sha: "${GIT_SHA1}"
+    razee.io/build-tag: "${BUILD_TAG}"
+    razee.io/branch: "${GIT_BRANCH}"
+type: array
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: featureflagsetld-controller
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        razee/watch-resource: "lite"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: featureflagsetld-controller
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: featureflagsetld-controller
+            razee/watch-resource: "lite"
+          name: featureflagsetld-controller
+        spec:
+          serviceAccountName: razeedeploy-sa
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - image: "quay.io/razee/featureflagsetld:${WAVE4_VERSION}"
+              resources:
+                limits:
+                  memory: 200Mi
+                  cpu: 1.0
+                requests:
+                  memory: 75Mi
+                  cpu: 40m
+              env:
+                - name: USER_AGENT_NAME
+                  value: razee-io/featureflagsetld
+                - name: USER_AGENT_VERSION
+                  value: "${WAVE4_VERSION}"
+                - name: CRD_WATCH_TIMEOUT_SECONDS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: razeedeploy-overrides
+                      key: CRD_WATCH_TIMEOUT_SECONDS
+                      optional: true
+              imagePullPolicy: Always
+              name: featureflagsetld-controller
+              livenessProbe:
+                exec:
+                  command:
+                    - sh/liveness.sh
+                initialDelaySeconds: 30
+                periodSeconds: 150
+                timeoutSeconds: 30
+                failureThreshold: 1
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      # name must match the spec fields below, and be in the form: <plural>.<group>
+      name: featureflagsetsld.deploy.razee.io
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        deploy.razee.io/Reconcile: "false"
+    spec:
+      # group name to use for REST API: /apis/<group>/<version>
+      group: deploy.razee.io
+      # either Namespaced or Cluster
+      scope: Namespaced
+      names:
+        # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+        plural: featureflagsetsld
+        # singular name to be used as an alias on the CLI and for display
+        singular: featureflagsetld
+        # kind is normally the CamelCased singular type. Your resource manifests use this.
+        kind: FeatureFlagSetLD
+        # shortNames allow shorter string to match your resource on the CLI
+        shortNames:
+          - ffsld
+      # list of versions supported by this CustomResourceDefinition
+      versions:
+        - name: v1alpha1
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: false
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+        - name: v1alpha2
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: true
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  allOf:
+                    - # you must define oneOf:
+                      oneOf:
+                        - required: [sdkKey]
+                        - required: [sdkKeyRef]
+                    - # you must define oneOf:
+                      oneOf:
+                        - # neither 'identityRef' nor 'identityKey' is used
+                          not:
+                            anyOf:
+                              - required: [identityRef]
+                              - required: [identityKey]
+                        - # 'identityRef' is used by itself
+                          required: [identityRef]
+                          not:
+                            required: [identityKey]
+                        - # 'identityRef' and 'identityKey' are used together
+                          required: [identityRef, identityKey]
+                  properties:
+                    sdkKey:
+                      type: string
+                    sdkKeyRef:
+                      type: object
+                      required: [valueFrom]
+                      properties:
+                        valueFrom:
+                          type: object
+                          required: [secretKeyRef]
+                          properties:
+                            secretKeyRef:
+                              type: object
+                              required: [name, key]
+                              properties:
+                                name:
+                                  type: string
+                                key:
+                                  type: string
+                                namespace:
+                                  type: string
+                    identityKey:
+                      type: string
+                    identityRef:
+                      type: object
+                      anyOf:
+                        - required: [envFrom]
+                        - required: [env]
+                      properties:
+                        envFrom:
+                          type: array
+                          items:
+                            type: object
+                            oneOf:
+                              - required: [configMapRef]
+                              - required: [secretMapRef]
+                              - required: [genericMapRef]
+                            properties:
+                              optional:
+                                type: boolean
+                              configMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              secretMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              genericMapRef:
+                                type: object
+                                required: [apiVersion, kind, name]
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            allOf:
+                              - required: [name]
+                              - # all array items should be oneOf ['value', 'valueFrom']
+                                oneOf:
+                                  - required: [value]
+                                    # if 'value', neither 'optional' nor 'default' may be used
+                                    not:
+                                      anyOf:
+                                        - required: [default]
+                                        - required: [optional]
+                                  - required: [valueFrom]
+                                    # if 'valueFrom', you must define oneOf:
+                                    oneOf:
+                                      - # neither 'optional' nor 'default' is used
+                                        not:
+                                          anyOf:
+                                            - required: [default]
+                                            - required: [optional]
+                                      - # 'optional' is used by itself
+                                        required: [optional]
+                                        not:
+                                          required: [default]
+                                      - # 'optional' and 'default' are used together IFF optional == true
+                                        required: [optional, default]
+                                        properties:
+                                          optional:
+                                            enum: [true]
+                            properties:
+                              optional:
+                                type: boolean
+                              default:
+                                x-kubernetes-int-or-string: true
+                              name:
+                                type: string
+                              value:
+                                x-kubernetes-int-or-string: true
+                              valueFrom:
+                                type: object
+                                oneOf:
+                                  - required: [configMapKeyRef]
+                                  - required: [secretKeyRef]
+                                  - required: [genericKeyRef]
+                                properties:
+                                  configMapKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  secretKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  genericKeyRef:
+                                    type: object
+                                    required: [apiVersion, kind, name, key]
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true

--- a/deployment/kubernetes/wave5.yaml.envsubst
+++ b/deployment/kubernetes/wave5.yaml.envsubst
@@ -1,0 +1,322 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: featureflagsetld-controller-list
+  annotations:
+    razee.io/git-repo: "${GIT_URL}"
+    razee.io/commit-sha: "${GIT_SHA1}"
+    razee.io/build-tag: "${BUILD_TAG}"
+    razee.io/branch: "${GIT_BRANCH}"
+type: array
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: featureflagsetld-controller
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        razee/watch-resource: "lite"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: featureflagsetld-controller
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: featureflagsetld-controller
+            razee/watch-resource: "lite"
+          name: featureflagsetld-controller
+        spec:
+          serviceAccountName: razeedeploy-sa
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - image: "quay.io/razee/featureflagsetld:${WAVE5_VERSION}"
+              resources:
+                limits:
+                  memory: 200Mi
+                  cpu: 1.0
+                requests:
+                  memory: 75Mi
+                  cpu: 40m
+              env:
+                - name: USER_AGENT_NAME
+                  value: razee-io/featureflagsetld
+                - name: USER_AGENT_VERSION
+                  value: "${WAVE5_VERSION}"
+                - name: CRD_WATCH_TIMEOUT_SECONDS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: razeedeploy-overrides
+                      key: CRD_WATCH_TIMEOUT_SECONDS
+                      optional: true
+              imagePullPolicy: Always
+              name: featureflagsetld-controller
+              livenessProbe:
+                exec:
+                  command:
+                    - sh/liveness.sh
+                initialDelaySeconds: 30
+                periodSeconds: 150
+                timeoutSeconds: 30
+                failureThreshold: 1
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      # name must match the spec fields below, and be in the form: <plural>.<group>
+      name: featureflagsetsld.deploy.razee.io
+      annotations:
+        razee.io/git-repo: "${GIT_URL}"
+        razee.io/commit-sha: "${GIT_SHA1}"
+        razee.io/build-tag: "${BUILD_TAG}"
+        razee.io/branch: "${GIT_BRANCH}"
+      labels:
+        deploy.razee.io/Reconcile: "false"
+    spec:
+      # group name to use for REST API: /apis/<group>/<version>
+      group: deploy.razee.io
+      # either Namespaced or Cluster
+      scope: Namespaced
+      names:
+        # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+        plural: featureflagsetsld
+        # singular name to be used as an alias on the CLI and for display
+        singular: featureflagsetld
+        # kind is normally the CamelCased singular type. Your resource manifests use this.
+        kind: FeatureFlagSetLD
+        # shortNames allow shorter string to match your resource on the CLI
+        shortNames:
+          - ffsld
+      # list of versions supported by this CustomResourceDefinition
+      versions:
+        - name: v1alpha1
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: false
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+        - name: v1alpha2
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
+          storage: true
+          subresources:
+            # status enables the status subresource.
+            status: {}
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  allOf:
+                    - # you must define oneOf:
+                      oneOf:
+                        - required: [sdkKey]
+                        - required: [sdkKeyRef]
+                    - # you must define oneOf:
+                      oneOf:
+                        - # neither 'identityRef' nor 'identityKey' is used
+                          not:
+                            anyOf:
+                              - required: [identityRef]
+                              - required: [identityKey]
+                        - # 'identityRef' is used by itself
+                          required: [identityRef]
+                          not:
+                            required: [identityKey]
+                        - # 'identityRef' and 'identityKey' are used together
+                          required: [identityRef, identityKey]
+                  properties:
+                    sdkKey:
+                      type: string
+                    sdkKeyRef:
+                      type: object
+                      required: [valueFrom]
+                      properties:
+                        valueFrom:
+                          type: object
+                          required: [secretKeyRef]
+                          properties:
+                            secretKeyRef:
+                              type: object
+                              required: [name, key]
+                              properties:
+                                name:
+                                  type: string
+                                key:
+                                  type: string
+                                namespace:
+                                  type: string
+                    identityKey:
+                      type: string
+                    identityRef:
+                      type: object
+                      anyOf:
+                        - required: [envFrom]
+                        - required: [env]
+                      properties:
+                        envFrom:
+                          type: array
+                          items:
+                            type: object
+                            oneOf:
+                              - required: [configMapRef]
+                              - required: [secretMapRef]
+                              - required: [genericMapRef]
+                            properties:
+                              optional:
+                                type: boolean
+                              configMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              secretMapRef:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                              genericMapRef:
+                                type: object
+                                required: [apiVersion, kind, name]
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            allOf:
+                              - required: [name]
+                              - # all array items should be oneOf ['value', 'valueFrom']
+                                oneOf:
+                                  - required: [value]
+                                    # if 'value', neither 'optional' nor 'default' may be used
+                                    not:
+                                      anyOf:
+                                        - required: [default]
+                                        - required: [optional]
+                                  - required: [valueFrom]
+                                    # if 'valueFrom', you must define oneOf:
+                                    oneOf:
+                                      - # neither 'optional' nor 'default' is used
+                                        not:
+                                          anyOf:
+                                            - required: [default]
+                                            - required: [optional]
+                                      - # 'optional' is used by itself
+                                        required: [optional]
+                                        not:
+                                          required: [default]
+                                      - # 'optional' and 'default' are used together IFF optional == true
+                                        required: [optional, default]
+                                        properties:
+                                          optional:
+                                            enum: [true]
+                            properties:
+                              optional:
+                                type: boolean
+                              default:
+                                x-kubernetes-int-or-string: true
+                              name:
+                                type: string
+                              value:
+                                x-kubernetes-int-or-string: true
+                              valueFrom:
+                                type: object
+                                oneOf:
+                                  - required: [configMapKeyRef]
+                                  - required: [secretKeyRef]
+                                  - required: [genericKeyRef]
+                                properties:
+                                  configMapKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  secretKeyRef:
+                                    type: object
+                                    required: [name, key]
+                                    properties:
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                                  genericKeyRef:
+                                    type: object
+                                    required: [apiVersion, kind, name, key]
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      key:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      type:
+                                        type: string
+                                        enum: [number, boolean, json]
+                data:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true

--- a/versions/wave0.mk
+++ b/versions/wave0.mk
@@ -1,0 +1,1 @@
+WAVE0_VERSION := 0.7.10

--- a/versions/wave1.mk
+++ b/versions/wave1.mk
@@ -1,0 +1,1 @@
+WAVE1_VERSION := 0.7.10

--- a/versions/wave2.mk
+++ b/versions/wave2.mk
@@ -1,0 +1,1 @@
+WAVE2_VERSION := 0.7.10

--- a/versions/wave3.mk
+++ b/versions/wave3.mk
@@ -1,0 +1,1 @@
+WAVE3_VERSION := 0.7.10

--- a/versions/wave4.mk
+++ b/versions/wave4.mk
@@ -1,0 +1,1 @@
+WAVE4_VERSION := 0.7.10

--- a/versions/wave5.mk
+++ b/versions/wave5.mk
@@ -1,0 +1,1 @@
+WAVE5_VERSION := 0.7.10


### PR DESCRIPTION
- include everything specific to this repo that isn't provided by
  onboarding to `repo-template-razee`
  - `versions/wave*.mk` specifies the version number of upstream's image
  - `deployment/kubernetes/wave*.yaml.envsubst` are our wave-specific
    deployment files based on but modified from upstream

ref: REL-1104
